### PR TITLE
Added support for multi accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,16 @@ python3 scoreGenerator.py my-profile
 {'cis-aws-foundations-benchmark': {'Score': 76}, 'aws-foundational-security-best-practices': {'Score': 88}}
 ```
 
-Tested with Python 3.7
+Tested with Python 3.7/3.10
+
+For use with Landing zones using a Security Hub administrator account, a 2nd parameter for other accounts in the organization can be passed to get their score:
+
+```python
+export AWS_DEFAULT_REGION=eu-west-2
+
+python3 scoreGenerator.py my-profile 123456789012
+{'cis-aws-foundations-benchmark': {'Score': 90}, 'aws-foundational-security-best-practices': {'Score': 90}}
+```
 
 ## Security
 


### PR DESCRIPTION
*Description of changes:*
To reduce the impact of #2, This change adds an optional parameter that filters on the [get_findings](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/securityhub.html#SecurityHub.Client.get_findings) call to only get data for a single account at a time. This is to prevent timeouts when attempting to get the score for multiple accounts. 